### PR TITLE
feat: add Plivo telephony provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,13 +320,13 @@ Inbound calls are handled via [Plivo Audio Streaming](https://www.plivo.com/docs
 #### 1. Prerequisites
 
 - A [Plivo account](https://www.plivo.com/)
-- A phone number purchased in the [Plivo Console](https://cx.plivo.com/)
+- A phone number purchased in the [Plivo Console](https://cx.plivo.com/?utm_source=github&utm_medium=oss&utm_campaign=azure-call-center)
 
 > During `azd up`, the setup wizard prompts for your Plivo Auth Token and stores it securely in Azure Key Vault.
 
 | Variable | Description | Where to find it |
 |----------|-------------|------------------|
-| `PLIVO_AUTH_TOKEN` | Your Plivo Auth Token, used to validate webhook signatures (`X-Plivo-Signature-V3`) | [Plivo Console](https://cx.plivo.com/) → Account → Keys & Credentials |
+| `PLIVO_AUTH_TOKEN` | Your Plivo Auth Token, used to validate webhook signatures (`X-Plivo-Signature-V3`) | [Plivo Console](https://cx.plivo.com/?utm_source=github&utm_medium=oss&utm_campaign=azure-call-center) → Account → Keys & Credentials |
 
 #### 2. Application / Webhook (Automatic)
 
@@ -335,7 +335,7 @@ The Plivo Application is **configured automatically** by the post-deploy script 
 <details>
 <summary>Manual setup (if needed)</summary>
 
-1. In the [Plivo Console](https://cx.plivo.com/), go to **Voice → Applications** and create (or edit) an application.
+1. In the [Plivo Console](https://cx.plivo.com/?utm_source=github&utm_medium=oss&utm_campaign=azure-call-center), go to **Voice → Applications** and create (or edit) an application.
 2. Set:
    - **Answer URL:** `https://<your-container-app-url>/plivo/answer`
    - **Answer Method:** `POST`

--- a/README.md
+++ b/README.md
@@ -348,9 +348,9 @@ The Plivo Application is **configured automatically** by the post-deploy script 
 Dial your Plivo phone number. The call connects to the real-time voice agent powered by Azure Voice Live.
 
 **How it works:**
-1. Plivo sends a request to `/plivo/answer` — the server validates the `X-Plivo-Signature-V3` signature and returns XML with a `<Stream>` element pointing at `wss://<host>/plivo/ws` (`bidirectional="true"`, `contentType="audio/x-l16;rate=16000"`)
+1. Plivo sends a request to `/plivo/answer` — the server validates the `X-Plivo-Signature-V3` signature and returns XML with a `<Stream>` element pointing at `wss://<host>/plivo/ws` (`bidirectional="true"`, `contentType="audio/x-l16;rate=8000"`)
 2. Plivo opens a WebSocket to `/plivo/ws` and sends a `start` event — the server captures the stream metadata, then bridges audio to Azure Voice Live
-3. The AI agent hears the caller (PCM resampled 16kHz→24kHz), generates a response, and audio is streamed back as `playAudio` events (resampled 24kHz→16kHz); barge-in clears buffered playback via a `clearAudio` event
+3. The AI agent hears the caller (PCM resampled 8kHz→24kHz), generates a response, and audio is streamed back as `playAudio` events (resampled 24kHz→8kHz); barge-in clears buffered playback via a `clearAudio` event
 
 ### 📞 Telephony with Infobip Client (Call Center Scenario)
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 | [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Azure-Samples/call-center-voice-agent-accelerator) | [![Open in Dev Containers](https://img.shields.io/static/v1?style=for-the-badge&label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/Azure-Samples/call-center-voice-agent-accelerator)
 |---|---|
 
-Welcome to the *Call Center Real-time Voice Agent* solution accelerator — a lightweight template for building speech-to-speech voice agents powered by **Azure Voice Live API**. It supports multiple telephony providers out of the box, including **Azure Communication Services (ACS)**, **Twilio**, **Infobip**, and **Genesys Cloud (AudioHook)**, plus a **web browser** client for quick testing. Bring your own telephony provider or use the built-in options. Start locally, deploy to Azure Container Apps.
+Welcome to the *Call Center Real-time Voice Agent* solution accelerator — a lightweight template for building speech-to-speech voice agents powered by **Azure Voice Live API**. It supports multiple telephony providers out of the box, including **Azure Communication Services (ACS)**, **Twilio**, **Plivo**, **Infobip**, and **Genesys Cloud (AudioHook)**, plus a **web browser** client for quick testing. Bring your own telephony provider or use the built-in options. Start locally, deploy to Azure Container Apps.
 
 The Azure voice live API is a solution enabling low-latency, high-quality speech to speech interactions for voice agents. The API is designed for developers seeking scalable and efficient voice-driven experiences as it eliminates the need to manually orchestrate multiple components. By integrating speech recognition, generative AI, and text to speech functionalities into a single, unified interface, it provides an end-to-end solution for creating seamless experiences. Learn more about [Azure Voice Live API](https://learn.microsoft.com/azure/ai-services/speech-service/voice-live).
 
 The Azure Communication Services Calls Automation APIs provide telephony integration and real-time event triggers to perform actions based on custom business logic specific to their domain. Within the call automation APIs developers can use simple AI powered APIs, which can be used to play personalized greeting messages, recognize conversational voice inputs to gather information on contextual questions to drive a more self-service model with customers, use sentiment analysis to improve customer service overall. Learn more about [Azure Communication Services (Call Automation)](https://learn.microsoft.com/azure/communication-services/concepts/call-automation/call-automation).
 
-Alternatively, telephony integration is supported through third-party providers, including [Twilio](https://www.twilio.com/docs/voice/media-streams) and [Infobip](https://www.infobip.com/docs/voice-and-video/calls).
+Alternatively, telephony integration is supported through third-party providers, including [Twilio](https://www.twilio.com/docs/voice/media-streams), [Plivo](https://www.plivo.com/docs/voice/xml/audio-streaming), and [Infobip](https://www.infobip.com/docs/voice-and-video/calls).
 
 
 <div align="center">
@@ -32,6 +32,7 @@ The solution includes:
   - **Web browser** — microphone/speaker via WebSocket (always available, great for testing)
   - **Azure Communication Services (ACS)** — enterprise PSTN with Call Automation (default)
   - **Twilio** — PSTN via Twilio Media Streams with webhook signature validation
+  - **Plivo** — PSTN via Plivo Audio Streaming with webhook signature validation
   - **Infobip** — PSTN via Infobip Calls API with WebSocket audio streaming
   - **Genesys Cloud** — AudioHook (Audio Connector) for real-time call audio streaming
 
@@ -311,6 +312,45 @@ Dial your Twilio phone number. The call connects to the real-time voice agent po
 1. Twilio sends a request to `/voice` — the server validates it and returns TwiML to start a media stream
 2. Twilio opens a WebSocket to `/twilio/ws` — the server verifies the embedded token, then bridges audio to Azure Voice Live
 3. The AI agent hears the caller, generates a response, and audio is streamed back through the same connection
+
+### 📞 Telephony with Plivo Client (Call Center Scenario)
+
+Inbound calls are handled via [Plivo Audio Streaming](https://www.plivo.com/docs/voice/xml/audio-streaming) — the server validates the request, returns Plivo XML that opens a bidirectional audio stream, and bridges the caller's audio to Azure Voice Live over a real-time WebSocket.
+
+#### 1. Prerequisites
+
+- A [Plivo account](https://www.plivo.com/)
+- A phone number purchased in the [Plivo Console](https://cx.plivo.com/)
+
+> During `azd up`, the setup wizard prompts for your Plivo Auth Token and stores it securely in Azure Key Vault.
+
+| Variable | Description | Where to find it |
+|----------|-------------|------------------|
+| `PLIVO_AUTH_TOKEN` | Your Plivo Auth Token, used to validate webhook signatures (`X-Plivo-Signature-V3`) | [Plivo Console](https://cx.plivo.com/) → Account → Keys & Credentials |
+
+#### 2. Application / Webhook (Automatic)
+
+The Plivo Application is **configured automatically** by the post-deploy script during `azd up`. It sets the Application's Answer URL to `https://<your-container-app-url>/plivo/answer` and assigns it to your phone number.
+
+<details>
+<summary>Manual setup (if needed)</summary>
+
+1. In the [Plivo Console](https://cx.plivo.com/), go to **Voice → Applications** and create (or edit) an application.
+2. Set:
+   - **Answer URL:** `https://<your-container-app-url>/plivo/answer`
+   - **Answer Method:** `POST`
+3. Save, then go to **Phone Numbers**, open your number, and assign this application to it.
+
+</details>
+
+#### 3. Call the Agent
+
+Dial your Plivo phone number. The call connects to the real-time voice agent powered by Azure Voice Live.
+
+**How it works:**
+1. Plivo sends a request to `/plivo/answer` — the server validates the `X-Plivo-Signature-V3` signature and returns XML with a `<Stream>` element pointing at `wss://<host>/plivo/ws` (`bidirectional="true"`, `contentType="audio/x-l16;rate=16000"`)
+2. Plivo opens a WebSocket to `/plivo/ws` and sends a `start` event — the server captures the stream metadata, then bridges audio to Azure Voice Live
+3. The AI agent hears the caller (PCM resampled 16kHz→24kHz), generates a response, and audio is streamed back as `playAudio` events (resampled 24kHz→16kHz); barge-in clears buffered playback via a `clearAudio` event
 
 ### 📞 Telephony with Infobip Client (Call Center Scenario)
 

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -8,6 +8,7 @@ VOICE_LIVE_MODEL=gpt-4o-mini
 # --- Telephony Provider: set ONE to activate that provider ---
 ACS_CONNECTION_STRING=<Find the connection string from your Communication Service resource>
 # TWILIO_AUTH_TOKEN=<Twilio Auth Token for webhook signature validation>
+# PLIVO_AUTH_TOKEN=<Plivo Auth Token for webhook signature validation>
 # INFOBIP_API_KEY=<Infobip API Key>
 # INFOBIP_API_BASE_URL=<e.g. https://xxxxx.api.infobip.com>
 # GENESYS_API_KEY=<Genesys API Key for AudioHook authentication>

--- a/server/app/providers/plivo/__init__.py
+++ b/server/app/providers/plivo/__init__.py
@@ -1,0 +1,108 @@
+"""Plivo provider route registration."""
+
+import asyncio
+import logging
+
+from quart import request, websocket
+
+from app.call_loop import run_call_loop
+from app.call_manager import CallManager
+from app.logging_config import new_correlation_id
+from app.provider_registry import register_provider
+
+logger = logging.getLogger(__name__)
+
+
+@register_provider(
+    name="plivo",
+    display_name="Plivo",
+    detect_key="PLIVO_AUTH_TOKEN",
+    required_config=["PLIVO_AUTH_TOKEN"],
+)
+def register_plivo_routes(app, call_manager: CallManager):
+    """Register Plivo answer webhook and Audio Streaming WebSocket routes."""
+    import os
+
+    from app.providers.plivo.event_handler import PlivoEventHandler
+    from app.providers.plivo.media_handler import PlivoMediaHandler
+
+    # Load provider-specific config
+    app.config["PLIVO_AUTH_TOKEN"] = os.getenv("PLIVO_AUTH_TOKEN", "")
+
+    plivo_handler = PlivoEventHandler(app.config)
+
+    @app.route("/plivo/answer", methods=["GET", "POST"])
+    async def plivo_answer():
+        """Handles incoming Plivo calls, returning Audio Streaming XML."""
+        new_correlation_id()
+        logger.info("Plivo /plivo/answer webhook called")
+
+        params = (
+            dict(await request.form) if request.method == "POST" else dict(request.args)
+        )
+        valid = plivo_handler.validate_request(
+            request.method, request.url, params, request.headers
+        )
+        if valid is None:
+            return "Service Unavailable", 503
+        if not valid:
+            return "Forbidden", 403
+
+        host_url = request.host_url.replace("http://", "https://", 1).rstrip("/")
+        ws_url = host_url.replace("https://", "wss://") + "/plivo/ws"
+        status_url = host_url + "/plivo/stream-status"
+        xml = plivo_handler.generate_stream_xml(ws_url, status_url)
+        return xml, 200, {"Content-Type": "text/xml"}
+
+    @app.route("/plivo/stream-status", methods=["POST"])
+    async def plivo_stream_status():
+        """Receives Plivo audio stream status callbacks (started/stopped/failed)."""
+        params = dict(await request.form)
+        event = params.get("Event")
+        # A "failed" stream is a real problem worth surfacing; log it louder.
+        # Teardown is not driven from here — the WebSocket close handles that.
+        log = logger.warning if event == "failed" else logger.info
+        log(
+            "Plivo stream status: event=%s streamId=%s callId=%s reason=%s",
+            event,
+            params.get("StreamID"),
+            params.get("CallUUID"),
+            params.get("StatusReason"),
+        )
+        return "", 200
+
+    @app.websocket("/plivo/ws")
+    async def plivo_ws():
+        """WebSocket endpoint for Plivo Audio Streaming to bridge to Voice Live."""
+        cid = new_correlation_id()
+        logger.info("Incoming Plivo Audio Streaming WebSocket connection")
+
+        handler = PlivoMediaHandler(app.config)
+        handler.plivo_ws = websocket
+        handler.correlation_id = cid
+        await handler.init_websocket(websocket)
+
+        if not await handler.authenticate_and_start():
+            return
+
+        # Use the server-generated correlation id as the call key (collision-proof);
+        # handler.stream_id remains available as Plivo protocol metadata.
+        call_id = cid
+        if not await call_manager.acquire(call_id, "plivo"):
+            await websocket.close(4429, "Too Many Connections")
+            return
+
+        try:
+            await run_call_loop(
+                call_manager=call_manager,
+                call_id=call_id,
+                ws=websocket,
+                handler=handler,
+            )
+        except asyncio.CancelledError:
+            logger.info("Plivo WebSocket cancelled")
+        except Exception:
+            logger.exception("Plivo WebSocket connection closed")
+        finally:
+            await call_manager.release(call_id)
+            await handler.cleanup()

--- a/server/app/providers/plivo/event_handler.py
+++ b/server/app/providers/plivo/event_handler.py
@@ -1,0 +1,55 @@
+"""Handler for Plivo answer-webhook validation and Audio Streaming XML generation."""
+
+import logging
+
+from plivo.utils.signature_v3 import validate_v3_signature
+from plivo.xml import ResponseElement, StreamElement
+
+logger = logging.getLogger(__name__)
+
+# Linear PCM 8kHz (telephony narrowband); resampled to Voice Live's 24kHz in the media handler.
+STREAM_CONTENT_TYPE = "audio/x-l16;rate=8000"
+
+
+class PlivoEventHandler:
+    """Validates Plivo webhook signatures and generates Audio Streaming XML."""
+
+    def __init__(self, config):
+        self.auth_token = config.get("PLIVO_AUTH_TOKEN", "")
+
+    def validate_request(
+        self, method: str, url: str, params: dict, headers
+    ) -> bool | None:
+        """Validate the Plivo V3 webhook signature. True/False, or None if no auth token configured."""
+        if not self.auth_token:
+            return None
+        signature = headers.get("X-Plivo-Signature-V3", "")
+        nonce = headers.get("X-Plivo-Signature-V3-Nonce", "")
+        if not signature or not nonce:
+            return False
+        try:
+            return validate_v3_signature(
+                method.upper(), url, nonce, self.auth_token, signature, params
+            )
+        except Exception:
+            # Fail closed: malformed input can make the SDK raise; treat as invalid, not a 500.
+            logger.warning(
+                "Plivo signature validation raised; treating as invalid", exc_info=True
+            )
+            return False
+
+    def generate_stream_xml(self, ws_url: str, status_url: str) -> str:
+        """Generate Plivo XML streaming call audio bidirectionally to ws_url."""
+        stream = StreamElement(
+            ws_url,
+            bidirectional=True,
+            audioTrack="inbound",
+            contentType=STREAM_CONTENT_TYPE,
+            keepCallAlive=True,
+            statusCallbackUrl=status_url,
+            statusCallbackMethod="POST",
+        )
+        resp = ResponseElement()
+        resp.add(stream)
+        logger.info("Returning Plivo XML with stream URL: %s", ws_url)
+        return resp.to_string(pretty=False)

--- a/server/app/providers/plivo/media_handler.py
+++ b/server/app/providers/plivo/media_handler.py
@@ -1,0 +1,211 @@
+"""Bridges the Plivo Audio Streaming WebSocket to the Azure Voice Live API."""
+
+import asyncio
+import audioop
+import base64
+import binascii
+import json
+import logging
+
+from app.handler.voicelive_media_handler import VoiceLiveMediaHandler
+
+logger = logging.getLogger(__name__)
+
+# Plivo streams PCM 8kHz; Voice Live expects PCM 24kHz. Resample both ways.
+PLIVO_SAMPLE_RATE = 8000
+VOICELIVE_SAMPLE_RATE = 24000
+PLAY_CONTENT_TYPE = "audio/x-l16"
+
+# Tear down after this many consecutive send failures (~2s of audio).
+MAX_CONSECUTIVE_SEND_FAILURES = 20
+
+
+class PlivoMediaHandler(VoiceLiveMediaHandler):
+    """Bridges Plivo Audio Streaming WebSocket to Azure Voice Live API.
+
+    Handles PCM 8kHz <-> 24kHz resampling and the Plivo streaming protocol.
+    """
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.plivo_ws = None
+        self.stream_id = None
+        self.call_id = None
+        self._ratecv_state_in = None
+        self._ratecv_state_out = None
+        self._consecutive_send_failures = 0
+
+    async def authenticate_and_start(self) -> bool:
+        """Read the first frame; require a well-formed 'start', else close. Returns True if started."""
+        try:
+            msg = await asyncio.wait_for(self.plivo_ws.receive(), timeout=30)
+        except TimeoutError:
+            logger.warning("[PlivoMediaHandler] Timed out waiting for start message")
+            await self.plivo_ws.close(4408, "Timeout")
+            return False
+        except Exception:
+            logger.warning(
+                "[PlivoMediaHandler] Error receiving start message", exc_info=True
+            )
+            return False
+
+        try:
+            data = json.loads(msg)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("[PlivoMediaHandler] Non-JSON message before start")
+            await self.plivo_ws.close(4400, "Bad Request")
+            return False
+
+        if data.get("event") != "start":
+            logger.warning(
+                "[PlivoMediaHandler] Expected 'start' as first frame, got: %s",
+                data.get("event"),
+            )
+            await self.plivo_ws.close(4400, "Bad Request")
+            return False
+
+        self._capture_start(data)
+        if not self.stream_id:
+            logger.warning("[PlivoMediaHandler] start event missing streamId")
+            await self.plivo_ws.close(4400, "Bad Request")
+            return False
+        return True
+
+    def _capture_start(self, data: dict):
+        """Record streamId/callId from a Plivo 'start' event."""
+        start_info = data.get("start", {})
+        self.stream_id = start_info.get("streamId")
+        self.call_id = start_info.get("callId")
+        logger.info(
+            "[PlivoMediaHandler] Stream started: streamId=%s, callId=%s, format=%s",
+            self.stream_id,
+            self.call_id,
+            start_info.get("mediaFormat"),
+        )
+
+    async def on_speech_started(self):
+        """Barge-in: clear Plivo playback and drop the TTS buffer."""
+        await self._send_clear_to_plivo()
+        if self._ambient_mixer is not None:
+            async with self._tts_buffer_lock:
+                self._tts_output_buffer.clear()
+                self._tts_playback_started = False
+
+    async def on_transcript_done(self, transcript: str):
+        """No-op — Plivo has no transcript channel."""
+        pass
+
+    # Outbound: PCM 24kHz -> 8kHz -> Plivo playAudio
+    async def _send_audio_to_client(self, audio_bytes: bytes):
+        """Resample PCM 24kHz to 8kHz and send to Plivo as a playAudio event."""
+        if not self.plivo_ws or not self.stream_id:
+            logger.debug(
+                "[PlivoMediaHandler] Dropping outbound audio; stream not ready/closed"
+            )
+            return
+
+        pcm_8k, self._ratecv_state_out = audioop.ratecv(
+            audio_bytes,
+            2,
+            1,
+            VOICELIVE_SAMPLE_RATE,
+            PLIVO_SAMPLE_RATE,
+            self._ratecv_state_out,
+        )
+        payload = base64.b64encode(pcm_8k).decode("ascii")
+
+        msg = {
+            "event": "playAudio",
+            "media": {
+                "contentType": PLAY_CONTENT_TYPE,
+                "sampleRate": PLIVO_SAMPLE_RATE,
+                "payload": payload,
+            },
+        }
+        try:
+            await self.plivo_ws.send(json.dumps(msg))
+            self._consecutive_send_failures = 0
+        except Exception as e:
+            self._consecutive_send_failures += 1
+            logger.warning(
+                "[PlivoMediaHandler] Audio send failed (%d consecutive): %s",
+                self._consecutive_send_failures,
+                e,
+            )
+            if self._consecutive_send_failures >= MAX_CONSECUTIVE_SEND_FAILURES:
+                logger.warning(
+                    "[PlivoMediaHandler] Too many consecutive send failures — "
+                    "closing WebSocket: streamId=%s",
+                    self.stream_id,
+                )
+                try:
+                    await self.plivo_ws.close(1011)  # Internal Error
+                except Exception:
+                    pass
+
+    async def _send_clear_to_plivo(self):
+        """Send a clearAudio event to stop current playback (barge-in)."""
+        if not self.plivo_ws or not self.stream_id:
+            return
+        self._ratecv_state_out = None
+        msg = {"event": "clearAudio", "streamId": self.stream_id}
+        try:
+            await self.plivo_ws.send(json.dumps(msg))
+        except Exception as e:
+            logger.warning("[PlivoMediaHandler] clearAudio send failed: %s", e)
+
+    # Inbound: Plivo PCM 8kHz -> 24kHz
+    def _receive_audio_from_client(self, data) -> tuple:
+        """Resample Plivo PCM/8kHz bytes to PCM 24kHz."""
+        pcm_24k, self._ratecv_state_in = audioop.ratecv(
+            data, 2, 1, PLIVO_SAMPLE_RATE, VOICELIVE_SAMPLE_RATE, self._ratecv_state_in
+        )
+        return pcm_24k, len(pcm_24k)
+
+    async def on_message(self, message):
+        """Process one incoming Plivo WebSocket message."""
+        try:
+            data = json.loads(message)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("[PlivoMediaHandler] Non-JSON message received")
+            return
+
+        event = data.get("event")
+
+        match event:
+            case "start":
+                # Duplicate start mid-stream — ignore so it can't clobber the established ids.
+                logger.warning(
+                    "[PlivoMediaHandler] Unexpected duplicate 'start' after stream "
+                    "established; ignoring (streamId=%s)",
+                    self.stream_id,
+                )
+
+            case "media":
+                payload = data.get("media", {}).get("payload", "")
+                if payload:
+                    try:
+                        pcm_bytes = base64.b64decode(payload)
+                        await self.handle_audio(pcm_bytes)
+                    except (binascii.Error, audioop.error, ValueError) as e:
+                        logger.warning(
+                            "[PlivoMediaHandler] Dropping bad media frame streamId=%s: %s",
+                            self.stream_id,
+                            e,
+                        )
+
+            case "dtmf":
+                # DTMF captured for observability only; not forwarded to Voice Live
+                # by design (matches the twilio/infobip providers).
+                digit = data.get("dtmf", {}).get("digit")
+                logger.info("[PlivoMediaHandler] DTMF received: %s", digit)
+
+            case "clearedAudio" | "playedStream":
+                logger.debug(
+                    "[PlivoMediaHandler] Playback event: %s streamId=%s",
+                    event,
+                    self.stream_id,
+                )
+
+            case _:
+                logger.debug("[PlivoMediaHandler] Unknown event: %s", event)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -29,6 +29,9 @@ acs = [
 twilio = [
     "twilio>=9.10.0",
 ]
+plivo = [
+    "plivo>=4.61.0",
+]
 infobip = []
 genesys = []
 

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -475,6 +475,15 @@ wheels = [
 ]
 
 [[package]]
+name = "decorator"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -784,6 +793,86 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1057,6 +1146,22 @@ realtime = [
 ]
 
 [[package]]
+name = "plivo"
+version = "4.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "decorator" },
+    { name = "lxml" },
+    { name = "pyjwt" },
+    { name = "requests" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/1a/19ff2110f5bd4ea35f2340f34ec0f66f0697c66376b58aa1739e39cf1cd9/plivo-4.61.0.tar.gz", hash = "sha256:4fcbc0fdef855c53029f6240424a6c92c78df588f618b168ccbd796a5cf70853", size = 58223, upload-time = "2026-06-12T10:31:48.585Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/0e/9f90f178d5f8f3bb0bafa5ec148bc89882210b92760b2383b895273bad52/plivo-4.61.0-py2.py3-none-any.whl", hash = "sha256:5ec6e3de3b8e594b608398d1f366851a9ff636c12be7366749333bd864588e32", size = 90567, upload-time = "2026-06-12T10:31:47.3Z" },
+]
+
+[[package]]
 name = "priority"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1319,6 +1424,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1410,6 +1524,9 @@ acs = [
     { name = "azure-communication-callautomation" },
     { name = "azure-eventgrid" },
 ]
+plivo = [
+    { name = "plivo" },
+]
 twilio = [
     { name = "twilio" },
 ]
@@ -1426,6 +1543,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "openai", extras = ["realtime"], specifier = ">=2.33.0" },
+    { name = "plivo", marker = "extra == 'plivo'", specifier = ">=4.61.0" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "quart", specifier = ">=0.20.0" },
@@ -1434,7 +1552,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "websockets", specifier = ">=15.0.1" },
 ]
-provides-extras = ["acs", "twilio", "infobip", "genesys"]
+provides-extras = ["acs", "twilio", "plivo", "infobip", "genesys"]
 
 [[package]]
 name = "websockets"


### PR DESCRIPTION
## Purpose
* Adds **Plivo** as a telephony provider, bridging Plivo Audio Streaming to the Azure Voice Live API so calls can run over Plivo alongside the existing provider(s).
* Follows the existing provider pattern: a self-contained `server/app/providers/plivo/` package that self-registers via the `@register_provider` decorator (no other files change).
* Closes #64.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
```

## How to Test
* Get the code
```
git clone https://github.com/sarveshpatil-plivo/call-center-voice-agent-accelerator.git
cd call-center-voice-agent-accelerator
git checkout plivo-provider
# set up server/ per the README
```
(or check out the PR directly against upstream with `gh pr checkout <PR-number>`)

* Test the code
```
```
* Set `PLIVO_AUTH_TOKEN` (the provider auto-detects when it's present).
* Point a Plivo number's Answer URL at `/plivo/answer`, place a call, and confirm the Audio Streaming WebSocket (`/plivo/ws`) bridges audio to Voice Live and back.

## What to Check
Verify that the following are valid
* `/plivo/answer` returns valid Audio Streaming XML; inbound requests are signature-validated.
* `/plivo/ws` bridges audio, resampling PCM 8kHz (Plivo) ↔ 24kHz (Voice Live).
* Provider self-registers via `@register_provider`; no existing providers are modified.

## Other Information
* New self-contained provider package; existing providers unchanged.
